### PR TITLE
Enabled this script to be usable even when the user is not 'git'

### DIFF
--- a/git-open
+++ b/git-open
@@ -1,9 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 
 # Copyright (c) 2013 Michael Hartl
+# Copyright (c) 2013 Aleksandar Simic
 # Released under the MIT License (http://opensource.org/licenses/MIT)
 
 # Opens the remote page for the repo (OS X only).
 URL=`git config --get remote.origin.url`
-GIT_PATTERN='s/git@(.*):(.*)/https:\/\/\1\/\2/' 
-echo $URL | sed -E $GIT_PATTERN | sed 's/\.git//' | xargs open 
+GIT_PATTERN='s/(.*)@(.*):(.*)/https:\/\/\2\/\3/'
+echo $URL | sed -E $GIT_PATTERN | sed 's/\.git//' | xargs open


### PR DESCRIPTION
GitHub functions under the assumption that the repos are always managed by the system user **git**, whereas there are some repos (not hosted on GitHub) that don't respect this convention. I've added a workaround for those cases.

Also, turned the shebang to Bourne from Bash as not every system has Bash installed by default.
