### PR TITLE
Add handling for Stash

### DIFF
--- a/git-open
+++ b/git-open
@@ -6,23 +6,36 @@
 
 # Opens the remote page for the repo (OS X only).
 URL=`git config --get remote.origin.url`
-# If it's ssh, drop the port
 CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
 
+SERVICE=stash
+PROTOCOL=ssh
 if [[ $URL =~ bitbucket ]]
 then
-  GIT_PATTERN='s/(.*)@(.*):(.*)/https:\/\/\2/'
+  SERVICE=bitbucket
 elif [[ $URL =~ github ]]
 then
-  GIT_PATTERN='s/(.*)@(.*):(.*)/https:\/\/\2/'
-else
-  if [[ $URL =~ ssh:// ]]
-  then
-    GIT_PATTERN='s/(.*)@(.*):([^\/]*)\/([^\/]*)\/(.*)\.git/https:\/\/\2\/projects\/\4\/repos\/\5\/browse\?at='"$CURRENT_BRANCH"/
-  else
-    GIT_PATTERN='s/(.*)@(.*):([^\/]*)\/([^\/]*)\/(.*)\.git/https:\/\/\2:\3\/projects\/\4\/repos\/\5\/browse\?at='"$CURRENT_BRANCH"/
-  fi
+  SERVICE=github
+fi
+if [[ $URL =~ https:// || $URL =~ http:// ]]
+then
+  PROTOCOL=http
 fi
 
-echo $URL | sed -E $GIT_PATTERN \
-          | xargs open
+case $SERVICE-$PROTOCOL in
+  stash-ssh )
+    # If it's ssh, drop the port
+    GIT_PATTERN='s/(.*)@([^:]*):?([^\/]*)\/([^\/]*)\/(.*)\.git/https:\/\/\2\/projects\/\4\/repos\/\5\/browse\?at='"$CURRENT_BRANCH"/
+    ;;
+  stash-http )
+    GIT_PATTERN='s/(.*)@([^:\/]*)(:?[^\/]*)\/(.*)scm\/([^\/]*)\/(.*)\.git/https:\/\/\2\3\/\4projects\/\5\/repos\/\6\/browse\?at='"$CURRENT_BRANCH"/
+    ;;
+  *-ssh )
+    GIT_PATTERN='s/(.*)@(.*):(.*)\.git/https:\/\/\2\/\3/'
+    ;;
+  *-http )
+    GIT_PATTERN='s/https?\:\/\/(([^@]*)@)?(.*)\.git/https:\/\/\3/'
+    ;;
+esac
+
+echo $URL | sed -E $GIT_PATTERN | xargs open

--- a/git-pull-request
+++ b/git-pull-request
@@ -1,28 +1,47 @@
-#!/bin/sh 
+#!/bin/sh
 
 # Copyright (c) 2013 Michael Hartl
 # Released under the MIT License (http://opensource.org/licenses/MIT)
 
 # Issues a pull request.
 URL=`git config --get remote.origin.url`
-# If it's ssh, drop the port
 CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
 
+SERVICE=stash
+PROTOCOL=ssh
 if [[ $URL =~ bitbucket ]]
 then
-  GIT_PATTERN='s/(.*)@(.*):(.*)/https:\/\/\2\/\/pull-request\/new/'
+  SERVICE=bitbucket
 elif [[ $URL =~ github ]]
 then
-  GIT_PATTERN='s/(.*)@(.*):(.*)/https:\/\/\2\/\/pull\/new\/'"$CURRENT_BRANCH"/
-else
-  if [[ $URL =~ ssh:// ]]
-  then
-    GIT_PATTERN='s/(.*)@(.*):([^\/]*)\/([^\/]*)\/(.*)\.git/https:\/\/\2\/projects\/\4\/repos\/\5\/pull-requests\?create\&sourceBranch='"$CURRENT_BRANCH"/
-  else
-    GIT_PATTERN='s/(.*)@(.*):([^\/]*)\/([^\/]*)\/(.*)\.git/https:\/\/\2:\3\/projects\/\4\/repos\/\5\/pull-requests\?create\&sourceBranch='"$CURRENT_BRANCH"/
-  fi
+  SERVICE=github
+fi
+if [[ $URL =~ https:// || $URL =~ http:// ]]
+then
+  PROTOCOL=http
 fi
 
+case $SERVICE-$PROTOCOL in
+  stash-ssh )
+    # If it's ssh, drop the port
+    GIT_PATTERN='s/(.*)@([^:]*):?([^\/]*)\/([^\/]*)\/(.*)\.git/https:\/\/\2\/projects\/\4\/repos\/\5\/pull-requests\?create\&sourceBranch='"$CURRENT_BRANCH"/
+    ;;
+  stash-http )
+    GIT_PATTERN='s/(.*)@([^:\/]*)(:?[^\/]*)\/(.*)scm\/([^\/]*)\/(.*)\.git/https:\/\/\2\3\/\4projects\/\5\/repos\/\6\/pull-requests\?create\&sourceBranch='"$CURRENT_BRANCH"/
+    ;;
+  github-ssh )
+    GIT_PATTERN='s/(.*)@(.*):(.*)\.git/https:\/\/\2\/\3\/pull\/new\/'"$CURRENT_BRANCH"/
+    ;;
+  github-http )
+    GIT_PATTERN='s/https?\:\/\/(([^@]*)@)?(.*)\.git/https:\/\/\3\/pull\/new\/'"$CURRENT_BRANCH"/
+    ;;
+  bitbucket-ssh )
+    GIT_PATTERN='s/(.*)@(.*):(.*)\.git/https:\/\/\2\/\3\/pull-request\/new/'
+    ;;
+  bitbucket-http )
+    GIT_PATTERN='s/https?\:\/\/(([^@]*)@)?(.*)\.git/https:\/\/\3\/pull-request\/new/'
+    ;;
+esac
+
 git push-branch
-echo $URL | sed -E $GIT_PATTERN \
-          | xargs open
+echo $URL | sed -E $GIT_PATTERN | xargs open

--- a/test-open-pr.sh
+++ b/test-open-pr.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+git init test-repo >/dev/null
+cd test-repo
+git checkout -b test-br 2>/dev/null
+touch foo
+git add foo
+git commit -m "foo" >/dev/null
+cat > open <<EOF
+#!/bin/sh
+
+echo \$*
+EOF
+chmod +x open
+cat > git-push-branch <<EOF
+#!/bin/sh
+EOF
+chmod +x git-push-branch
+export PATH=`pwd`:$PATH
+git remote add origin foo
+
+test_open () {
+  REMOTE=$1
+  EXPECTED=$2
+  git remote set-url origin $REMOTE
+  RESULT=`../git-open`
+  if [ "$RESULT" = "$EXPECTED" ]
+  then
+    echo "passed: open $REMOTE"
+  else
+    echo "FAILED: open: Expected $EXPECTED (for origin $REMOTE) but got $RESULT"
+  fi
+}
+
+test_open https://mwatson@bitbucket.org/atlassian/amps.git https://bitbucket.org/atlassian/amps
+test_open git@bitbucket.org:atlassian/amps.git https://bitbucket.org/atlassian/amps
+test_open git@github.com:mhartl/git-utils.git https://github.com/mhartl/git-utils
+test_open git://github.com/mhartl/git-utils.git https://github.com/mhartl/git-utils
+test_open https://github.com/mhartl/git-utils.git https://github.com/mhartl/git-utils
+test_open ssh://git@stash.atlassian.com:7999/stash/stash.git https://stash.atlassian.com/projects/stash/repos/stash/browse?at=test-br
+test_open https://mwatson@stash.atlassian.com:7990/scm/stash/stash.git https://stash.atlassian.com:7990/projects/stash/repos/stash/browse?at=test-br
+test_open ssh://git@stash.atlassian.com/stash/stash.git https://stash.atlassian.com/projects/stash/repos/stash/browse?at=test-br
+test_open https://mwatson@stash.atlassian.com/scm/stash/stash.git https://stash.atlassian.com/projects/stash/repos/stash/browse?at=test-br
+test_open https://mwatson@stash.atlassian.com/stash/scm/stash/stash.git https://stash.atlassian.com/stash/projects/stash/repos/stash/browse?at=test-br
+test_open https://mwatson@stash.atlassian.com:7990/stash/scm/stash/stash.git https://stash.atlassian.com:7990/stash/projects/stash/repos/stash/browse?at=test-br
+
+test_pr () {
+  REMOTE=$1
+  EXPECTED=$2
+  git remote set-url origin $REMOTE
+  RESULT=`../git-pull-request`
+  if [ "$RESULT" = "$EXPECTED" ]
+  then
+    echo "passed: pull-request $REMOTE"
+  else
+    echo "FAILED: pull-request: Expected $EXPECTED (for origin $REMOTE) but got $RESULT"
+  fi
+}
+
+test_pr https://mwatson@bitbucket.org/atlassian/amps.git https://bitbucket.org/atlassian/amps/pull-request/new
+test_pr git@bitbucket.org:atlassian/amps.git https://bitbucket.org/atlassian/amps/pull-request/new
+test_pr git@github.com:mhartl/git-utils.git https://github.com/mhartl/git-utils/pull/new/test-br
+test_pr git://github.com/mhartl/git-utils.git https://github.com/mhartl/git-utils/pull/new/test-br
+test_pr https://github.com/mhartl/git-utils.git https://github.com/mhartl/git-utils/pull/new/test-br
+test_pr ssh://git@stash.atlassian.com:7999/stash/stash.git https://stash.atlassian.com/projects/stash/repos/stash/pull-requests?create\&sourceBranch=test-br
+test_pr https://mwatson@stash.atlassian.com:7990/scm/stash/stash.git https://stash.atlassian.com:7990/projects/stash/repos/stash/pull-requests?create\&sourceBranch=test-br
+test_pr ssh://git@stash.atlassian.com/stash/stash.git https://stash.atlassian.com/projects/stash/repos/stash/pull-requests?create\&sourceBranch=test-br
+test_pr https://mwatson@stash.atlassian.com/scm/stash/stash.git https://stash.atlassian.com/projects/stash/repos/stash/pull-requests?create\&sourceBranch=test-br
+test_pr https://mwatson@stash.atlassian.com/stash/scm/stash/stash.git https://stash.atlassian.com/stash/projects/stash/repos/stash/pull-requests?create\&sourceBranch=test-br
+test_pr https://mwatson@stash.atlassian.com:7990/stash/scm/stash/stash.git https://stash.atlassian.com:7990/stash/projects/stash/repos/stash/pull-requests?create\&sourceBranch=test-br
+
+cd ..
+rm -rf test-repo


### PR DESCRIPTION
Hey Michael,

I saw your post here https://news.ycombinator.com/item?id=5822989 and wanted to add support for Stash as well. In the process I have changed your simple code somewhat and introduced a lot of code replication between git-open and git-pull-request. However, I added a "unit test" for both with a range of possible URLs (OK, it fails for the git protocol, but you're not going to be pushing on git://).

Let me know what you think.

Matt
